### PR TITLE
Add OrderLines API endpoint

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,7 @@ resources share a common API. Resources that are currently supported by this lib
 * Images
 * Inventories
 * Orders
+* OrderLines
 * Sales
 * Shops
 * Special Orders

--- a/lib/lightspeed/account.rb
+++ b/lib/lightspeed/account.rb
@@ -8,6 +8,7 @@ require_relative 'item_attribute_sets'
 require_relative 'images'
 require_relative 'inventories'
 require_relative 'orders'
+require_relative 'order_lines'
 require_relative 'price_levels'
 require_relative 'sales'
 require_relative 'shops'
@@ -32,6 +33,7 @@ module Lightspeed
       :ItemAttributeSets,
       :Items,
       :Orders,
+      :OrderLines,
       :PriceLevels,
       :Sales,
       :Shops,

--- a/lib/lightspeed/order_line.rb
+++ b/lib/lightspeed/order_line.rb
@@ -1,0 +1,18 @@
+require_relative 'resource'
+
+module Lightspeed
+  class OrderLine < Lightspeed::Resource
+    fields(
+      orderLineID: :integer,
+      quantity: :integer,
+      price: :decimal,
+      originalPrice: :decimal,
+      checkedIn: :integer,
+      numReceived: :integer,
+      orderID: :integer,
+      itemID: :integer,
+      timeStamp: :datetime,
+      total: :decimal
+    )
+  end
+end

--- a/lib/lightspeed/order_lines.rb
+++ b/lib/lightspeed/order_lines.rb
@@ -1,0 +1,8 @@
+require_relative 'collection'
+
+require_relative 'order_line'
+
+module Lightspeed
+  class OrderLines < Lightspeed::Collection
+  end
+end

--- a/lib/lightspeed/version.rb
+++ b/lib/lightspeed/version.rb
@@ -1,3 +1,3 @@
 module Lightspeed
-  VERSION = "0.3.1"
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
This PR extending gem about `OrderLines` endpoint to handle `PurchaseOrderLineItems`
LS documentation: https://developers.lightspeedhq.com/retail/endpoints/OrderLine/