### PR TITLE
Added parentheses inside Lightspeed::Request#units to avoid ambigious…

### DIFF
--- a/lib/lightspeed/request.rb
+++ b/lib/lightspeed/request.rb
@@ -117,7 +117,7 @@ module Lightspeed
     end
 
     def units
-      @raw_request.is_a? Net::HTTP::Get ? 1 : 10
+      @raw_request.is_a?(Net::HTTP::Get) ? 1 : 10
     end
   end
 end


### PR DESCRIPTION
… interpretation

This prevents from raising `TypeError` - now the Ruby interpreter treats the whole ternary operator statement as an arguments to `Object#is_a?` method