### PR TITLE
Remove relationships from item

### DIFF
--- a/lib/lightspeed/item.rb
+++ b/lib/lightspeed/item.rb
@@ -53,7 +53,7 @@ module Lightspeed
       Tags: :hash
     )
 
-    relationships :ItemMatrix, :Category, :Images, DefaultVendor: :Vendor
+    # relationships :ItemMatrix, :Category, :Images, DefaultVendor: :Vendor
 
     def prices
       @prices ||= Lightspeed::Prices.new(self.Prices)

--- a/spec/lightspeed/item_spec.rb
+++ b/spec/lightspeed/item_spec.rb
@@ -7,7 +7,7 @@ describe Lightspeed::Item do
     Lightspeed::Item.new(context: account, attributes: { "itemID" => 2 })
   end
 
-  it "can fetch an item's ItemMatrix" do
+  xit "can fetch an item's ItemMatrix" do
     subject.itemMatrixID = 1
     VCR.use_cassette("account/ItemMatrix/show") do
       matrix = subject.item_matrix
@@ -15,13 +15,13 @@ describe Lightspeed::Item do
     end
   end
 
-  it "does not fetch an item matrix if itemMatrixID is nil" do
+  xit "does not fetch an item matrix if itemMatrixID is nil" do
     # Yes, Lightspeed's API returns 0 for an ID, rather than `null`.
     subject.itemMatrixID = "0"
     expect(subject.item_matrix).to be_nil
   end
 
-  it "can fetch an item's default Vendor" do
+  xit "can fetch an item's default Vendor" do
     subject.defaultVendorID = "1"
     VCR.use_cassette("account/vendors/show") do
       vendor = subject.default_vendor
@@ -29,7 +29,7 @@ describe Lightspeed::Item do
     end
   end
 
-  it "does not fetch an item's default vendor if defaultVendorID is nil" do
+  xit "does not fetch an item's default vendor if defaultVendorID is nil" do
     subject.defaultVendorID = "0"
     expect(subject.default_vendor).to be_nil
   end


### PR DESCRIPTION
Removed relationships from `Lightspeed::Item` class which causes another API request for every relation specified. This is a really resource-intensive operation.